### PR TITLE
Corrected check for nodejs in dojo.js

### DIFF
--- a/dojo.js
+++ b/dojo.js
@@ -142,7 +142,7 @@
 		return now && has(name);
 	};
 
-	has.add("host-node", typeof process == "object" && /node(\.exe)?$/.test(process.execPath));
+	has.add("host-node", typeof process == "object" && /node(\.exe||js)?$/.test(process.execPath));
 	if(has("host-node")){
 		// fixup the default config for node.js environment
 		require("./_base/configNode.js").config(defaultConfig);


### PR DESCRIPTION
I have ubuntu 11.04 with nodejs-0.4.12 installed from repository.
And when I run node dojo.js check for node on 145 lines is non correct:
console.log(/node(.exe)?$/.test(process.execPath)); ->> false
because process.execPath return /usr/bin/nodejs.

May be a problem only for me.

Thanks.
Maksim
