### PR TITLE
Unit test, relative.html, looks for wrong line-ending

### DIFF
--- a/tests/_base/loader/requirejs/relative/relative-tests.js
+++ b/tests/_base/loader/requirejs/relative/relative-tests.js
@@ -13,7 +13,7 @@ require({
                     t.is("one", one.name);
                     t.is("two", one.twoName);
                     t.is("three", one.threeName);
-                    t.is("hello world", one.message.replace(/\n/g, ""));
+                    t.is("hello world", one.message.replace(/(\r\n|\r|\n)/g, ""));
                 }
             ]
         );


### PR DESCRIPTION
Current unit test assumes `one.message` consists only of `\n` characters as
line-endings. This is not the case, and as such this test fails.

Expanding the pattern to include all line-endings resolves the issue.

``` javascript
t.is("hello world", one.message.replace(/(\r\n|\r|\n)/g, ""));
```
