### PR TITLE
dojo.store.JsonRest + sortParam - url encoding

### DIFF
--- a/store/JsonRest.js
+++ b/store/JsonRest.js
@@ -167,7 +167,7 @@ return declare("dojo.store.JsonRest", base, {
 			query += (query || hasQuestionMark ? "&" : "?") + (sortParam ? sortParam + '=' : "sort(");
 			for(var i = 0; i<options.sort.length; i++){
 				var sort = options.sort[i];
-				query += (i > 0 ? "," : "") + (sort.descending ? '-' : '+') + encodeURIComponent(sort.attribute);
+				query += (i > 0 ? "," : "") + encodeURIComponent((sort.descending ? '-' : '+') + sort.attribute);
 			}
 			if(!sortParam){
 				query += ")";


### PR DESCRIPTION
if you specify a sortParam attribute, the sorting-info is serialized as request parameters. e.g.:

``` javascript
store.query({}, {
    sort:[{attribute:'test',descending:false}]
});
```

this results in:

```
http://...{target}?sortAttr=+test
```

Unfortunately, the + sign represents a blank inside an url. So on the server if I fetch the parameter-value i get ' test'.

More info here: http://bugs.dojotoolkit.org/ticket/14537
