### PR TITLE
Add Micro API event 'moduleLoaded'

### DIFF
--- a/dojo.js
+++ b/dojo.js
@@ -1171,6 +1171,8 @@
 			if (/^require\*/.test(module.mid)) {
 				delete modules[module.mid];
 			}
+			//raise moduleLvent
+			signal("moduleLoaded", [module.result, module.mid]);
 		},
 
 		circleTrace = [],


### PR DESCRIPTION
by adding this event to the end of finishExec(), developers will
be able to subscribe to notifications when individual modules are 
loaded. This need arose specifically so I would be able to tag 
modules with their id's using module.prototype for id-based routing
and activation.
